### PR TITLE
Remove unnecessary data-epi-property-name

### DIFF
--- a/apps/frontend/src/components/cms/experience/BlankExperience/index.tsx
+++ b/apps/frontend/src/components/cms/experience/BlankExperience/index.tsx
@@ -15,7 +15,7 @@ import { type Metadata } from "next";
  */
 export const BlankExperienceExperience : CmsComponent<BlankExperienceDataFragment> = ({ data }) => {
     const composition = getFragmentData(CompositionDataFragmentDoc, (data as ExperienceDataFragment).composition)
-    return <CmsEditable as="div" className="vb:experience" cmsFieldName="unstructuredData">
+    return <CmsEditable as="div" className="vb:experience">
         { composition && isNode(composition) && <OptimizelyComposition node={composition} /> }
     </CmsEditable>
 }

--- a/apps/frontend/src/components/cms/experience/BlogSectionExperience/index.tsx
+++ b/apps/frontend/src/components/cms/experience/BlogSectionExperience/index.tsx
@@ -15,7 +15,7 @@ export const BlogSectionExperienceExperience : CmsComponent<BlogSectionExperienc
     const composition = getFragmentData(CompositionDataFragmentDoc, getFragmentData(ExperienceDataFragmentDoc, data)?.composition)
     const initialData = await getBlogPosts({ locale: contentLink.locale ?? 'en', parentKey: contentLink.key ?? 'n/a' })
     return <div className="" data-component="BlogSectionExperience">
-        <CmsEditable as="div" className="py-8" cmsFieldName="unstructuredData">
+        <CmsEditable as="div" className="py-8">
             { composition && isNode(composition) && <OptimizelyComposition node={composition} /> }
         </CmsEditable>
         { contentLink.key && contentLink.locale &&


### PR DESCRIPTION
Delivery does not need to render data-epi-property-name as all sections are identified by data-epi-block-id

That may change in future when we combine layout & unstructuredData together but for now it is not needed